### PR TITLE
Add support for extra prefix for base_url.

### DIFF
--- a/falcon_swagger_ui/resources.py
+++ b/falcon_swagger_ui/resources.py
@@ -59,7 +59,7 @@ class SwaggerUiResource(object):
         resp.body = self.templates.render('index.html', **self.context)
 
 
-def register_swaggerui_app(app, base_url, api_url, page_title='Swagger UI', favicon_url=None, config=None):
+def register_swaggerui_app(app, swagger_uri, api_url, page_title='Swagger UI', favicon_url=None, config=None, uri_prefix=""):
 
     """:type app: falcon.API"""
 
@@ -84,7 +84,7 @@ def register_swaggerui_app(app, base_url, api_url, page_title='Swagger UI', favi
     default_context = {
         'page_title': page_title,
         'favicon_url': favicon_url,
-        'base_url': base_url,
+        'base_url': uri_prefix + swagger_uri,
         'api_url': api_url,
         'app_name': default_config.pop('app_name'),
         'client_realm': default_config.pop('client_realm'),
@@ -97,10 +97,10 @@ def register_swaggerui_app(app, base_url, api_url, page_title='Swagger UI', favi
 
     app.add_sink(
         StaticSinkAdapter(static_folder),
-        r'%s/(?P<filepath>.*)\Z' % base_url,
+        r'%s/(?P<filepath>.*)\Z' % swagger_uri,
     )
 
     app.add_route(
-        base_url,
+        swagger_uri,
         SwaggerUiResource(templates_folder, default_context)
     )


### PR DESCRIPTION
# Description
Allow support for a prefixed URL with the use of an extra parameter `url_prefix` (default=`""`) in `register_swaggerui_app`. 
Also changed `base_url` to `swagger_uri` to avoid confusion with actual `base_url` used by Swagger's template.

# Use case
My service is deployed in Mesos Marathon, and there is an extra prefix added to the URL, such as `base_url` would redirect to root of the URL instead of the root of my service API.

Example: if `base_url = "/swagger"`, the Swagger distribution resources will be search under `https://{mesos_marathon_base_url}/swagger/` whereas I would want it be `https://{mesos_marathon_base_url}/{my_service_prefix}/swagger/`.

Setting the parameter `url_prefix="/my_service_prefix"` (without trailing slash too) will then allow to serve Swagger UI on the same route (`/swagger`) with its resources being fetched at the right place.