### PR TITLE
Use Response.set_stream() instead of deprecated stream_len

### DIFF
--- a/falcon_swagger_ui/resources.py
+++ b/falcon_swagger_ui/resources.py
@@ -44,8 +44,9 @@ class StaticSinkAdapter(object):
         if not os.path.exists(file_path):
             raise falcon.HTTPNotFound()
         else:
-            resp.stream = open(file_path, 'rb')
-            resp.stream_len = os.path.getsize(file_path)
+            stream = open(file_path, 'rb')
+            stream_len = os.path.getsize(file_path)
+            resp.set_stream(stream, stream_len)
 
 
 class SwaggerUiResource(object):


### PR DESCRIPTION
 _stream_len_ no longer works in Falcon 3 and is [apparently deprecated](https://falcon.readthedocs.io/en/stable/api/request_and_response.html#falcon.Response.stream_len), although there is no warning. [_set_stream()_](https://falcon.readthedocs.io/en/stable/api/request_and_response.html#falcon.Response.set_stream) is a convenience method for setting both _stream_ and _content_length_. 

With this change, _falcon-swagger-ui_ seems to work fine with Falcon 3.0.0a1.