### PR TITLE
Validate file name in static sink

### DIFF
--- a/falcon_swagger_ui/resources.py
+++ b/falcon_swagger_ui/resources.py
@@ -32,21 +32,22 @@ class TemplateRenderer(object):
 class StaticSinkAdapter(object):
 
     def __init__(self, static_path):
-        self.static_path = static_path
+        curr_dir = os.path.dirname(os.path.abspath(__file__))
+        self.static_dir = os.path.join(curr_dir, static_path)
 
     def __call__(self, req, resp, filepath):
         resp.content_type = mimetypes.guess_type(filepath)[0]
-        curr_dir = os.path.dirname(os.path.abspath(__file__))
-        file_path = os.path.join(
-            os.path.join(curr_dir, self.static_path),
-            filepath
+        file_path = os.path.normpath(
+            os.path.join(self.static_dir, filepath)
         )
+        if not file_path.startswith(self.static_dir + os.sep):
+            raise falcon.HTTPNotFound()
         if not os.path.exists(file_path):
             raise falcon.HTTPNotFound()
-        else:
-            stream = open(file_path, 'rb')
-            stream_len = os.path.getsize(file_path)
-            resp.set_stream(stream, stream_len)
+
+        stream = open(file_path, 'rb')
+        stream_len = os.path.getsize(file_path)
+        resp.set_stream(stream, stream_len)
 
 
 class SwaggerUiResource(object):


### PR DESCRIPTION
The static sink does not properly validate the filename, which means you can use it to request arbitrary files.

For example:

```
$ curl localhost:8002/swagger/%2Fetc%2Fpasswd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...

$ curl localhost:8002/swagger/..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2Fetc/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...
```