### PR TITLE
naming parameters on register_swaggerui_app on README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,9 @@ Example application:
     favicon_url = 'https://falconframework.org/favicon-32x32.png'
 
     register_swaggerui_app(
-        app, SWAGGERUI_URL, SCHEMA_URL,
+        app=app,
+        swagger_uri=SWAGGERUI_URL,
+        api_url=SCHEMA_URL,
         page_title=page_title,
         favicon_url=favicon_url,
         config={'supportedSubmitMethods': ['get'], }


### PR DESCRIPTION
I edited the example on README naming the parameters of the `register_swaggerui_app` function.